### PR TITLE
Alert when imagemagick is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Features
 - Reports broken links
 
 
+Prerequisites
+--------------------------------------------------
+
+Snapcrawl requires [PhantomJS][1] and [ImageMagick][2].
+
+
 Install
 --------------------------------------------------
 
@@ -68,3 +74,9 @@ Notes
 1. If a URL cannot be found, Snapcrawl will report to stderr. 
    You can create a report by running `snapcrawl go example.com 2> err.txt`
 
+
+
+---
+
+[1]: http://phantomjs.org/download.html
+[2]: https://imagemagick.org/script/download.php

--- a/bin/snapcrawl
+++ b/bin/snapcrawl
@@ -10,6 +10,10 @@ rescue MissingPhantomJS => e
   message = "Cannot find phantomjs executable in the path, please install it first."
   say! "\n\n!undred!#{e.class}!txtrst!\n#{message}"
   exit 2
+rescue MissingImageMagick=> e
+  message = "Cannot find convert (ImageMagick) executable in the path, please install it first."
+  say! "\n\n!undred!#{e.class}!txtrst!\n#{message}"
+  exit 3
 rescue => e
   puts e.backtrace.reverse if ENV['DEBUG']
   say! "\n\n!undred!#{e.class}!txtrst!\n#{e.message}"

--- a/lib/snapcrawl/crawler.rb
+++ b/lib/snapcrawl/crawler.rb
@@ -11,6 +11,7 @@ module Snapcrawl
   include Colsole
 
   class MissingPhantomJS < StandardError; end
+  class MissingImageMagick < StandardError; end
 
   class Crawler
     def self.instance
@@ -33,6 +34,7 @@ module Snapcrawl
 
     def execute(args)
       raise MissingPhantomJS unless command_exist? "phantomjs"
+      raise MissingImageMagick unless command_exist? "convert"
       crawl args['<url>'].dup, opts_from_args(args)
     end
 
@@ -235,6 +237,7 @@ module Snapcrawl
       $keep_stdout, $keep_stderr = $stdout, $stderr
       $stdout, $stderr = StringIO.new, StringIO.new
       yield
+    ensure
       $stdout, $stderr = $keep_stdout, $keep_stderr
     end
   end


### PR DESCRIPTION
- Add friendly error message when ImageMagick is not installed
- Add Prerequisites section in the README to notify about the need of PhantomJS and ImageMagick
- Fix "silent errors" situation in the snap method

Closes #6 