### PR TITLE
Fixes round

### DIFF
--- a/lib/snapcrawl.rb
+++ b/lib/snapcrawl.rb
@@ -1,4 +1,6 @@
 require 'snapcrawl/version'
 require 'snapcrawl/crawler'
 
+require 'byebug' if ENV['BYEBUG']
+
 self.extend Snapcrawl

--- a/snapcrawl.gemspec
+++ b/snapcrawl.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'docopt', '~> 0.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'webshot', '~> 0.1'
+  s.add_runtime_dependency 'httparty', '~> 0.17'
 end

--- a/spec/fixtures/crawler/broken
+++ b/spec/fixtures/crawler/broken
@@ -10,7 +10,7 @@
 [0;32m-----> Visit: http://localhost:4567/broken
 [0m       [0;34mSnap![0m  Snapping picture... done
        [0;34mCrawl![0m Extracting links... [0;31mFAILED
-[0m[0;31m  !    HTTP Error: 404 Not Found  at http://localhost:4567/broken
+[0m[0;31m  !    HTTP Error: 404 Not Found at http://localhost:4567/broken
 [0m
 [0;32m-----> Visit: http://localhost:4567/ok
 [0m       [0;34mSnap![0m  Snapping picture... done

--- a/spec/fixtures/crawler/regex
+++ b/spec/fixtures/crawler/regex
@@ -10,7 +10,7 @@
 [0;32m-----> Visit: http://localhost:4567/broken
 [0m       Snap:  Skipping. Does not match regex
        [0;34mCrawl![0m Extracting links... [0;31mFAILED
-[0m[0;31m  !    HTTP Error: 404 Not Found  at http://localhost:4567/broken
+[0m[0;31m  !    HTTP Error: 404 Not Found at http://localhost:4567/broken
 [0m
 [0;32m-----> Visit: http://localhost:4567/ok
 [0m       Snap:  Skipping. Does not match regex

--- a/spec/snapcrawl/crawler_spec.rb
+++ b/spec/snapcrawl/crawler_spec.rb
@@ -21,7 +21,7 @@ describe Crawler do
       expect{ subject.handle %W[go #{url} -a0] }.to output_fixture('crawler/single')
     end
 
-    context "with a broken page" do
+    context "with a broken page", :focus do
       it "reports a problem and continues past the error" do
         expect{ subject.handle %W[go #{url} -a0 -d5] }.to output_fixture('crawler/broken')
       end

--- a/spec/snapcrawl/crawler_spec.rb
+++ b/spec/snapcrawl/crawler_spec.rb
@@ -21,7 +21,7 @@ describe Crawler do
       expect{ subject.handle %W[go #{url} -a0] }.to output_fixture('crawler/single')
     end
 
-    context "with a broken page", :focus do
+    context "with a broken page" do
       it "reports a problem and continues past the error" do
         expect{ subject.handle %W[go #{url} -a0 -d5] }.to output_fixture('crawler/broken')
       end


### PR DESCRIPTION
- Switch from `open-uri` to `HTTParty` - as it seems to be able to handle protocol downgrade redirects (HTTPS > HTTP) natively - Closes #16
- Change error handling, since HTTParty does not raise exceptions by default. Result to the user should be the same unless we screwed something.
- There code that was responsible for converting relative links to absolute was completely wrong. Now using `URI.join` instead - this means that previously snapcrawl sometimes crawled deeper than it should have.
