### PR TITLE
Don't error out on A tags that are malformed

### DIFF
--- a/lib/snapcrawl/crawler.rb
+++ b/lib/snapcrawl/crawler.rb
@@ -193,7 +193,7 @@ module Snapcrawl
         link = link.attribute('href').to_s
 
         # Remove #hash
-        link.gsub!(/#.+$/, '')
+        link = link.gsub(/#.+$/, '')
         next if link.empty?
 
         # Remove links to specific extensions and protocols


### PR DESCRIPTION
There's a WP site I'm crawling that has some (very poorly coded) plugins in it.  For whatever reason, the plugin writers are using an "a" tag with no HREF to manage their slideshow.  Because of the lack of href, I get an error when the link tries to replace the "#" because it's just an empty string.

Now, I know this isn't valid HTML -- but I can't really change it without breaking things on the site.  I figured I'd see if you'd allow an invalid "a" tag to not error out before forking.

Thanks for your consideration.

